### PR TITLE
Adds -y flag to apt-get to force install

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -27,7 +27,7 @@ then
     info 's3cmd not found, start installing it'
     wget -O- -q http://s3tools.org/repo/deb-all/stable/s3tools.key | sudo apt-key add -
     sudo wget -O/etc/apt/sources.list.d/s3tools.list http://s3tools.org/repo/deb-all/stable/s3tools.list
-    sudo apt-get update && sudo apt-get install s3cmd
+    sudo apt-get update && sudo apt-get install -y s3cmd
     success 's3cmd installed succesfully'
 else
     info 'skip s3cmd install, command already available'

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,3 +1,3 @@
 name: s3put
-version: 0.0.3
+version: 0.0.4
 description: s3put step


### PR DESCRIPTION
I had a deploy fail on Wercker's new Ewok stack as apt-get install was waiting for confirmation on stdin.
![apt-get waiting for confirmation](https://cloud.githubusercontent.com/assets/1416698/7020692/0b42e866-dd13-11e4-9606-04a9e6d4d733.png)
This PR adds the `-y` flag to `apt-get install s3cmd` to force the installation of s3cmd's dependencies.

I also bumped the version number.
